### PR TITLE
Update settings mangling.

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1,11 +1,9 @@
 # Django settings for mozbuzz project.
 
-DEBUG  = False
+DEBUG = False
 TEMPLATE_DEBUG = DEBUG
 
-ADMINS = (
-    ('Felipe Lerena', 'felipelerena@gmail.com'),
-)
+ADMINS = ()
 
 MANAGERS = ADMINS
 
@@ -91,7 +89,7 @@ MIDDLEWARE_CLASSES = (
 
 ROOT_URLCONF = 'mozbuzz.urls'
 
-TEMPLATE_DIRS = None#override me in local settings
+TEMPLATE_DIRS = None  # override me in local settings
 
 INSTALLED_APPS = (
     'django.contrib.auth',

--- a/settings_local.py.example
+++ b/settings_local.py.example
@@ -1,4 +1,3 @@
-from settings import *
 import os
 
 ROOT_PATH = os.path.dirname(__file__)
@@ -10,7 +9,7 @@ MEDIA_URL = "/media/"
 MEDIA_ROOT = os.path.join(ROOT_PATH,"media")
 SITE_URL = "http://127.0.0.1:8000"
 
-
+ADMINS = ()
 
 DATABASES = {
     'default': {


### PR DESCRIPTION
 Move the ADMINS setting to the local settings file. Do not import settings from the settigns_local module. If the settings_local module is being used as DJANGO_SETTINGS_MODULE, this will need to be changed to the mozbuzz.settings module in the webserver/wsgi config
